### PR TITLE
Controlnet implementation

### DIFF
--- a/composite_renderer/interface.go
+++ b/composite_renderer/interface.go
@@ -7,10 +7,10 @@ type Renderer interface {
 }
 
 // New returns a new Renderer. Set yonsai to true if you have 4 images to render, false if you have n images to render.
-func New(yonsai bool) (Renderer, error) {
+func New(yonsai bool) Renderer {
 	if yonsai {
-		return &rendererImpl{}, nil
+		return &rendererImpl{}
 	} else {
-		return &tilerImpl{}, nil
+		return &tilerImpl{}
 	}
 }

--- a/entities/controlnet.go
+++ b/entities/controlnet.go
@@ -1,19 +1,36 @@
 package entities
 
-// ControlNetParameters represents the parameters for a ControlNet processing unit.
+// ControlNetParameters represents the parameters for a ControlNet processing unit. Use /controlnet/control_types endpoint to get both the module and model lists.
+// By using (*stable_diffusion_api.ControlnetTypes).GetCache or stable_diffusion_api.ControlnetTypesCache to access the endpoint and get the lists of modules and models.
 type ControlNetParameters struct {
-	InputImage    *string `json:"input_image,omitempty"` // InputImage represents the image used in this unit. The default is nil.
-	Mask          *string `json:"mask,omitempty"`        // Mask represents the pixel_perfect filter for the image. The default is nil.
-	Module        string  `json:"module,omitempty"`      // Module defines the preprocessor for the image. Defaults to "none".
-	Model         string  `json:"model,omitempty"`       // Model defines the name of the model for conditioning. Defaults to "None".
-	Weight        int     `json:"weight"`                // Weight denotes this unit's weight. Defaults to 1.
-	ResizeMode    string  `json:"resize_mode"`           // ResizeMode determines how to resize the input image. Defaults to "Scale to Fit (Inner Fit)".
-	Lowvram       bool    `json:"lowvram"`               // Lowvram flag indicating if the system should compensate for low GPU memory. Defaults to false.
-	ProcessorRes  int     `json:"processor_res"`         // ProcessorRes is the resolution for the preprocessor. Defaults to 64.
-	ThresholdA    int     `json:"threshold_a"`           // ThresholdA is the first parameter of the preprocessor when it accepts arguments. Defaults to 64.
-	ThresholdB    int     `json:"threshold_b"`           // ThresholdB, like ThresholdA, is a preprocessor parameter and defaults to 64.
-	GuidanceStart float64 `json:"guidance_start"`        // GuidanceStart is the generation ratio at which this unit starts having an impact. Defaults to 0.0.
-	GuidanceEnd   float64 `json:"guidance_end"`          // GuidanceEnd is the generation ratio at which this unit discontinues its impact. Defaults to 1.0.
-	ControlMode   string  `json:"control_mode"`          // ControlMode determines the balance between the prompt and control model. Defaults to "Balanced".
-	PixelPerfect  bool    `json:"pixel_perfect"`         // PixelPerfect flag enables the pixel-perfect preprocessor. Defaults to false.
+	InputImage    *string     `json:"input_image,omitempty"` // InputImage represents the image used in this unit. The default is nil.
+	Mask          *string     `json:"mask,omitempty"`        // Mask represents the pixel_perfect filter for the image. The default is nil.
+	Module        string      `json:"module,omitempty"`      // Module defines the preprocessor for the image. Defaults to "none". Use /controlnet/module_list in the api
+	Model         string      `json:"model,omitempty"`       // Model defines the name of the model for conditioning. Defaults to "None". Use /controlnet/model_list in the api
+	Weight        float64     `json:"weight"`                // Weight denotes this unit's weight. Defaults to 1.
+	ResizeMode    ResizeMode  `json:"resize_mode"`           // ResizeMode determines how to resize the input image. Defaults to "Scale to Fit (Inner Fit)".
+	Lowvram       bool        `json:"lowvram"`               // Lowvram flag indicating if the system should compensate for low GPU memory. Defaults to false.
+	ProcessorRes  int         `json:"processor_res"`         // ProcessorRes is the resolution for the preprocessor. Defaults to 64.
+	ThresholdA    int         `json:"threshold_a"`           // ThresholdA is the first parameter of the preprocessor when it accepts arguments. Defaults to 64.
+	ThresholdB    int         `json:"threshold_b"`           // ThresholdB, like ThresholdA, is a preprocessor parameter and defaults to 64.
+	GuidanceStart float64     `json:"guidance_start"`        // GuidanceStart is the generation ratio at which this unit starts having an impact. Defaults to 0.0.
+	GuidanceEnd   float64     `json:"guidance_end"`          // GuidanceEnd is the generation ratio at which this unit discontinues its impact. Defaults to 1.0.
+	ControlMode   ControlMode `json:"control_mode"`          // ControlMode determines the balance between the prompt and control model. Defaults to "Balanced".
+	PixelPerfect  bool        `json:"pixel_perfect"`         // PixelPerfect flag enables the pixel-perfect preprocessor. Defaults to false.
 }
+
+type ControlMode string
+
+const (
+	ControlModeBalanced ControlMode = "Balanced"
+	ControlModePrompt   ControlMode = "My prompt is more important"
+	ControlModeControl  ControlMode = "ControlNet is more important"
+)
+
+type ResizeMode string
+
+const (
+	ResizeModeJustResize ResizeMode = "Just Resize"
+	ResizeModeScaleToFit ResizeMode = "Scale to Fit (Inner Fit)"
+	ResizeModeEnvelope   ResizeMode = "Envelope (Outer Fit)"
+)

--- a/entities/controlnet.go
+++ b/entities/controlnet.go
@@ -3,20 +3,20 @@ package entities
 // ControlNetParameters represents the parameters for a ControlNet processing unit. Use /controlnet/control_types endpoint to get both the module and model lists.
 // By using (*stable_diffusion_api.ControlnetTypes).GetCache or stable_diffusion_api.ControlnetTypesCache to access the endpoint and get the lists of modules and models.
 type ControlNetParameters struct {
-	InputImage    *string     `json:"input_image,omitempty"` // InputImage represents the image used in this unit. The default is nil.
-	Mask          *string     `json:"mask,omitempty"`        // Mask represents the pixel_perfect filter for the image. The default is nil.
-	Module        string      `json:"module,omitempty"`      // Module defines the preprocessor for the image. Defaults to "none". Use /controlnet/module_list in the api
-	Model         string      `json:"model,omitempty"`       // Model defines the name of the model for conditioning. Defaults to "None". Use /controlnet/model_list in the api
-	Weight        float64     `json:"weight"`                // Weight denotes this unit's weight. Defaults to 1.
-	ResizeMode    ResizeMode  `json:"resize_mode"`           // ResizeMode determines how to resize the input image. Defaults to "Scale to Fit (Inner Fit)".
-	Lowvram       bool        `json:"lowvram"`               // Lowvram flag indicating if the system should compensate for low GPU memory. Defaults to false.
-	ProcessorRes  int         `json:"processor_res"`         // ProcessorRes is the resolution for the preprocessor. Defaults to 64.
-	ThresholdA    int         `json:"threshold_a"`           // ThresholdA is the first parameter of the preprocessor when it accepts arguments. Defaults to 64.
-	ThresholdB    int         `json:"threshold_b"`           // ThresholdB, like ThresholdA, is a preprocessor parameter and defaults to 64.
-	GuidanceStart float64     `json:"guidance_start"`        // GuidanceStart is the generation ratio at which this unit starts having an impact. Defaults to 0.0.
-	GuidanceEnd   float64     `json:"guidance_end"`          // GuidanceEnd is the generation ratio at which this unit discontinues its impact. Defaults to 1.0.
-	ControlMode   ControlMode `json:"control_mode"`          // ControlMode determines the balance between the prompt and control model. Defaults to "Balanced".
-	PixelPerfect  bool        `json:"pixel_perfect"`         // PixelPerfect flag enables the pixel-perfect preprocessor. Defaults to false.
+	InputImage    *string     `json:"input_image,omitempty"`    // InputImage represents the image used in this unit. The default is nil.
+	Mask          *string     `json:"mask,omitempty"`           // Mask represents the pixel_perfect filter for the image. The default is nil.
+	Module        string      `json:"module,omitempty"`         // Module defines the preprocessor for the image. Defaults to "none". Use /controlnet/module_list in the api
+	Model         string      `json:"model,omitempty"`          // Model defines the name of the model for conditioning. Defaults to "None". Use /controlnet/model_list in the api
+	Weight        float64     `json:"weight,omitempty"`         // Weight denotes this unit's weight. Defaults to 1.
+	ResizeMode    ResizeMode  `json:"resize_mode,omitempty"`    // ResizeMode determines how to resize the input image. Defaults to "Scale to Fit (Inner Fit)".
+	Lowvram       bool        `json:"lowvram,omitempty"`        // Lowvram flag indicating if the system should compensate for low GPU memory. Defaults to false.
+	ProcessorRes  int         `json:"processor_res,omitempty"`  // ProcessorRes is the resolution for the preprocessor. Defaults to 64.
+	ThresholdA    int         `json:"threshold_a,omitempty"`    // ThresholdA is the first parameter of the preprocessor when it accepts arguments. Defaults to 64.
+	ThresholdB    int         `json:"threshold_b,omitempty"`    // ThresholdB, like ThresholdA, is a preprocessor parameter and defaults to 64.
+	GuidanceStart float64     `json:"guidance_start,omitempty"` // GuidanceStart is the generation ratio at which this unit starts having an impact. Defaults to 0.0.
+	GuidanceEnd   float64     `json:"guidance_end,omitempty"`   // GuidanceEnd is the generation ratio at which this unit discontinues its impact. Defaults to 1.0.
+	ControlMode   ControlMode `json:"control_mode,omitempty"`   // ControlMode determines the balance between the prompt and control model. Defaults to "Balanced".
+	PixelPerfect  bool        `json:"pixel_perfect,omitempty"`  // PixelPerfect flag enables the pixel-perfect preprocessor. Defaults to false.
 }
 
 type ControlMode string

--- a/entities/image_to_image.go
+++ b/entities/image_to_image.go
@@ -13,7 +13,7 @@ import (
 
 type MessageAttachment struct {
 	discordgo.MessageAttachment
-	Image string `json:"image"`
+	Image *string `json:"image"`
 }
 
 func UnmarshalImageToImageRequest(data []byte) (ImageToImageRequest, error) {

--- a/imagine_queue/embed_helpers.go
+++ b/imagine_queue/embed_helpers.go
@@ -1,0 +1,236 @@
+package imagine_queue
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/SpenserCai/sd-webui-discord/utils"
+	"github.com/bwmarrin/discordgo"
+	"log"
+	"stable_diffusion_bot/entities"
+	"time"
+)
+
+func imageEmbedFromAttachment(webhook *discordgo.WebhookEdit, embed *discordgo.MessageEmbed, image *entities.MessageAttachment, thumbnail *bytes.Reader) (err error) {
+	if embed == nil {
+		embed = &discordgo.MessageEmbed{
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+	}
+
+	var files []*discordgo.File
+
+	if thumbnail != nil {
+		embed.Thumbnail = &discordgo.MessageEmbedThumbnail{
+			URL: "attachment://thumbnail.png",
+		}
+		files = append(files, &discordgo.File{
+			Name:   "thumbnail.png",
+			Reader: thumbnail,
+		})
+	}
+
+	var reader *bytes.Reader
+	if image != nil {
+		if image.Image == nil && image.URL != "" {
+			image.Image = new(string)
+			*image.Image, err = utils.GetImageBase64(image.URL)
+			if err != nil {
+				log.Printf("Error getting image base64: %v", err)
+				return
+			}
+		}
+		embed.Type = discordgo.EmbedTypeImage
+		embed.Image = &discordgo.MessageEmbedImage{
+			URL: fmt.Sprintf("attachment://%v", image.Filename),
+		}
+	}
+
+	reader, err = utils.GetImageReaderByBase64(safeDereference(image.Image))
+	if err != nil {
+		log.Printf("Error getting image reader by base64: %v", err)
+		return
+	}
+
+	files = append(files, &discordgo.File{
+		Name:   image.Filename,
+		Reader: reader,
+	})
+
+	embeds := []*discordgo.MessageEmbed{embed}
+
+	webhook.Embeds = &embeds
+	webhook.Files = files
+	return
+}
+
+func imageEmbedFromReader(webhook *discordgo.WebhookEdit, embed *discordgo.MessageEmbed, reader *bytes.Reader, thumbnail *bytes.Reader) (err error) {
+	if embed == nil {
+		embed = &discordgo.MessageEmbed{
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+	}
+
+	var files []*discordgo.File
+
+	if thumbnail != nil {
+		embed.Thumbnail = &discordgo.MessageEmbedThumbnail{
+			URL: "attachment://thumbnail.png",
+		}
+		files = append(files, &discordgo.File{
+			Name:   "thumbnail.png",
+			Reader: thumbnail,
+		})
+	}
+
+	embed.Type = discordgo.EmbedTypeImage
+	embed.Image = &discordgo.MessageEmbedImage{
+		URL: fmt.Sprintf("attachment://%v", "image.png"),
+	}
+
+	files = append(files, &discordgo.File{
+		Name:   "image.png",
+		Reader: reader,
+	})
+
+	embeds := []*discordgo.MessageEmbed{embed}
+
+	webhook.Embeds = &embeds
+	webhook.Files = files
+	return
+}
+
+func generationEmbedDetails(embed *discordgo.MessageEmbed, newGeneration *entities.ImageGenerationRequest, c *QueueItem) *discordgo.MessageEmbed {
+	if newGeneration == nil || c == nil {
+		log.Printf("WARNING: generationEmbedDetails called with nil %T or %T", newGeneration, c)
+		return nil
+	}
+	var title string
+	switch {
+	case c.Type == ItemTypeImg2Img || (c.Img2ImgItem.MessageAttachment != nil && c.Img2ImgItem.Image != nil):
+		title = "Image to Image"
+	case c.ControlnetItem.MessageAttachment != nil && c.ControlnetItem.Image != nil:
+		title = "Controlnet"
+	case c.Type == ItemTypeVariation:
+		title = "Variation"
+	case c.Type == ItemTypeReroll:
+		title = "Reroll"
+	case c.Type == ItemTypeUpscale:
+		title = "Upscale"
+	default:
+		title = "Finished generation"
+	}
+	if embed == nil {
+		log.Printf("WARNING: generationEmbedDetails called with nil %T", embed)
+		embed = &discordgo.MessageEmbed{}
+	}
+	embed.Type = discordgo.EmbedTypeImage
+	embed.Title = title
+	embed.URL = "https://github.com/ellypaws/sd-discord-bot/"
+	embed.Author = &discordgo.MessageEmbedAuthor{
+		Name:         c.DiscordInteraction.Member.User.Username,
+		IconURL:      c.DiscordInteraction.Member.User.AvatarURL(""),
+		ProxyIconURL: "https://i.keiau.space/data/00144.png",
+	}
+	embed.Description = fmt.Sprintf("<@%s> asked me to process %v steps in %v, cfg: `%0.1f`, seed: `%v`, sampler: `%s`",
+		c.DiscordInteraction.Member.User.ID, newGeneration.Steps, time.Since(newGeneration.CreatedAt),
+		newGeneration.CFGScale, newGeneration.Seed, newGeneration.SamplerName)
+	// store as "2015-12-31T12:00:00.000Z"
+	embed.Timestamp = time.Now().Format(time.RFC3339)
+	embed.Footer = &discordgo.MessageEmbedFooter{
+		Text:    "https://github.com/ellypaws/sd-discord-bot/",
+		IconURL: "https://i.keiau.space/data/00144.png",
+	}
+	embed.Fields = []*discordgo.MessageEmbedField{
+		{
+			Name:   "Checkpoint",
+			Value:  fmt.Sprintf("`%v`", safeDereference(newGeneration.Checkpoint)),
+			Inline: false,
+		},
+		{
+			Name:   "VAE",
+			Value:  fmt.Sprintf("`%v`", safeDereference(newGeneration.VAE)),
+			Inline: true,
+		},
+		{
+			Name:   "Hypernetwork",
+			Value:  fmt.Sprintf("`%v`", safeDereference(newGeneration.Hypernetwork)),
+			Inline: true,
+		},
+		{
+			Name:  "Prompt",
+			Value: fmt.Sprintf("```\n%s\n```", newGeneration.Prompt),
+		},
+	}
+	return embed
+}
+
+func rerollVariationComponents(amount int) *[]discordgo.MessageComponent {
+	var actionsRow []discordgo.ActionsRow
+
+	var firstRow []discordgo.MessageComponent
+
+	// First Row: "imagine_variation" buttons and "Re-roll" button
+	for i := 1; i <= amount; i++ {
+		firstRow = append(firstRow, discordgo.Button{
+			Label:    fmt.Sprintf("%d", i),
+			Style:    discordgo.SecondaryButton,
+			Disabled: false,
+			CustomID: fmt.Sprintf("imagine_variation_%d", i),
+			Emoji: discordgo.ComponentEmoji{
+				Name: "♻️",
+			},
+		})
+	}
+
+	firstRow = append(firstRow, discordgo.Button{
+		Label:    "Re-roll",
+		Style:    discordgo.PrimaryButton,
+		Disabled: false,
+		CustomID: "imagine_reroll",
+		Emoji: discordgo.ComponentEmoji{
+			Name: "🎲",
+		},
+	})
+
+	actionsRow = append(actionsRow, discordgo.ActionsRow{
+		Components: firstRow,
+	})
+
+	var secondRow []discordgo.MessageComponent
+
+	// Second Row: "imagine_upscale" buttons and "Delete" button
+	for i := 1; i <= amount; i++ {
+		secondRow = append(secondRow, discordgo.Button{
+			Label:    fmt.Sprintf("%d", i),
+			Style:    discordgo.SecondaryButton,
+			Disabled: false,
+			CustomID: fmt.Sprintf("imagine_upscale_%d", i),
+			Emoji: discordgo.ComponentEmoji{
+				Name: "⬆️",
+			},
+		})
+	}
+
+	// "Delete" button
+	secondRow = append(secondRow, discordgo.Button{
+		Label:    "Delete",
+		Style:    discordgo.DangerButton,
+		Disabled: false,
+		CustomID: "imagine_delete",
+		Emoji: discordgo.ComponentEmoji{
+			Name: "🗑️",
+		},
+	})
+
+	actionsRow = append(actionsRow, discordgo.ActionsRow{
+		Components: secondRow,
+	})
+
+	// Create the ActionsRows
+	var rows []discordgo.MessageComponent
+	for _, row := range actionsRow {
+		rows = append(rows, row)
+	}
+
+	return &rows
+}

--- a/imagine_queue/generate.go
+++ b/imagine_queue/generate.go
@@ -39,6 +39,7 @@ func (q *queueImplementation) processImagineGrid(newGeneration *entities.ImageGe
 			if err != nil {
 				log.Printf("Error updating configuration: %v", err)
 			}
+			config, _ = q.stableDiffusionAPI.GetConfig()
 		}
 	}
 

--- a/imagine_queue/generate.go
+++ b/imagine_queue/generate.go
@@ -19,6 +19,7 @@ func (q *queueImplementation) processImagineGrid(newGeneration *entities.ImageGe
 	config, err := q.stableDiffusionAPI.GetConfig()
 	if err != nil {
 		log.Printf("Error getting config: %v", err)
+		return err
 	} else {
 		if !ptrStringCompare(newGeneration.Checkpoint, config.SDModelCheckpoint) ||
 			!ptrStringCompare(newGeneration.VAE, config.SDVae) ||
@@ -38,8 +39,13 @@ func (q *queueImplementation) processImagineGrid(newGeneration *entities.ImageGe
 			}))
 			if err != nil {
 				log.Printf("Error updating configuration: %v", err)
+				return err
 			}
-			config, _ = q.stableDiffusionAPI.GetConfig()
+			config, err = q.stableDiffusionAPI.GetConfig()
+			if err != nil {
+				log.Printf("Error getting config: %v", err)
+				return err
+			}
 		}
 	}
 
@@ -94,14 +100,12 @@ func (q *queueImplementation) processImagineGrid(newGeneration *entities.ImageGe
 	defaultBatchCount, err := q.defaultBatchCount()
 	if err != nil {
 		log.Printf("Error getting default batch count: %v", err)
-
 		return err
 	}
 
 	defaultBatchSize, err := q.defaultBatchSize()
 	if err != nil {
 		log.Printf("Error getting default batch size: %v", err)
-
 		return err
 	}
 	newGeneration.InteractionID = c.DiscordInteraction.ID
@@ -115,6 +119,7 @@ func (q *queueImplementation) processImagineGrid(newGeneration *entities.ImageGe
 	_, err = q.imageGenerationRepo.Create(context.Background(), newGeneration)
 	if err != nil {
 		log.Printf("Error creating image generation record: %v\n", err)
+		return err
 	}
 
 	generationDone := make(chan bool)

--- a/imagine_queue/generate.go
+++ b/imagine_queue/generate.go
@@ -217,7 +217,16 @@ func (q *queueImplementation) processImagineGrid(newGeneration *entities.ImageGe
 			Name:   "imagine_" + time.Now().Format("20060102150405") + ".png",
 			Reader: compositeImage,
 		})
-		embeds[0].Image.URL = fmt.Sprintf("attachment://%v", files[0].Name)
+		if len(embeds) > 0 {
+			embeds[0].Image.URL = fmt.Sprintf("attachment://%v", files[0].Name)
+		} else {
+			embeds = append(embeds, &discordgo.MessageEmbed{
+				Type: discordgo.EmbedTypeImage,
+				Image: &discordgo.MessageEmbedImage{
+					URL: fmt.Sprintf("attachment://%v", files[0].Name),
+				},
+			})
+		}
 
 		if c.Enabled && c.Type != ItemTypeImg2Img {
 			extraImage, err := q.compositeRenderer.TileImages(imageBufs[4:])

--- a/imagine_queue/queue.go
+++ b/imagine_queue/queue.go
@@ -111,24 +111,41 @@ type QueueItem struct {
 	RestoreFaces       bool
 	ADetailerString    string // use AppendSegModelByString
 	Attachments        map[string]*entities.MessageAttachment
-	DenoisingStrength  float64
-	Checkpoint         *string
-	VAE                *string
-	Hypernetwork       *string
+	Img2ImgItem
+	ControlnetItem
+	Checkpoint   *string
+	VAE          *string
+	Hypernetwork *string
+}
+
+type Img2ImgItem struct {
+	Image             *entities.MessageAttachment
+	DenoisingStrength float64
+}
+
+type ControlnetItem struct {
+	Image        *entities.MessageAttachment
+	ControlMode  string
+	ResizeMode   string
+	Type         string
+	Preprocessor string // also called the module in entities.ControlNetParameters
+	Model        string
 }
 
 func DefaultQueueItem() *QueueItem {
 	return &QueueItem{
-		NegativePrompt:    defaultNegative,
-		Steps:             20,
-		Seed:              -1,
-		SamplerName1:      "Euler a",
-		Type:              ItemTypeImagine,
-		UseHiresFix:       false,
-		HiresSteps:        20,
-		HiresUpscaleRate:  1.0,
-		CfgScale:          7.0,
-		DenoisingStrength: 0.7,
+		NegativePrompt:   defaultNegative,
+		Steps:            20,
+		Seed:             -1,
+		SamplerName1:     "Euler a",
+		Type:             ItemTypeImagine,
+		UseHiresFix:      false,
+		HiresSteps:       20,
+		HiresUpscaleRate: 1.0,
+		CfgScale:         7.0,
+		Img2ImgItem: Img2ImgItem{
+			DenoisingStrength: 0.7,
+		},
 	}
 }
 

--- a/imagine_queue/queue.go
+++ b/imagine_queue/queue.go
@@ -69,10 +69,7 @@ func New(cfg Config) (Queue, error) {
 		return nil, errors.New("missing default settings repository")
 	}
 
-	compositeRenderer, err := composite_renderer.New(true)
-	if err != nil {
-		return nil, err
-	}
+	compositeRenderer := composite_renderer.New(false)
 
 	return &queueImplementation{
 		stableDiffusionAPI:  cfg.StableDiffusionAPI,
@@ -119,17 +116,18 @@ type QueueItem struct {
 }
 
 type Img2ImgItem struct {
-	Image             *entities.MessageAttachment
+	*entities.MessageAttachment
 	DenoisingStrength float64
 }
 
 type ControlnetItem struct {
-	Image        *entities.MessageAttachment
-	ControlMode  string
-	ResizeMode   string
+	*entities.MessageAttachment
+	ControlMode  entities.ControlMode
+	ResizeMode   entities.ResizeMode
 	Type         string
 	Preprocessor string // also called the module in entities.ControlNetParameters
 	Model        string
+	Enabled      bool
 }
 
 func DefaultQueueItem() *QueueItem {
@@ -145,6 +143,10 @@ func DefaultQueueItem() *QueueItem {
 		CfgScale:         7.0,
 		Img2ImgItem: Img2ImgItem{
 			DenoisingStrength: 0.7,
+		},
+		ControlnetItem: ControlnetItem{
+			ControlMode: entities.ControlModeBalanced,
+			ResizeMode:  entities.ResizeModeScaleToFit,
 		},
 	}
 }

--- a/imagine_queue/text_to_image.go
+++ b/imagine_queue/text_to_image.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/SpenserCai/sd-webui-discord/utils"
 	"log"
+	"stable_diffusion_bot/discord_bot/handlers"
 	"stable_diffusion_bot/entities"
 	"strconv"
 )
@@ -247,7 +248,7 @@ func (q *queueImplementation) processCurrentImagine() {
 		err = q.processImagineGrid(newGeneration, c)
 		if err != nil {
 			log.Printf("Error processing imagine grid: %v", err)
-
+			handlers.Errors[handlers.ErrorResponse](q.botSession, c.DiscordInteraction, err)
 			return
 		}
 	}()

--- a/repositories/image_generations/sqlite.go
+++ b/repositories/image_generations/sqlite.go
@@ -63,7 +63,9 @@ func NewRepository(cfg *Config) (Repository, error) {
 }
 
 func (repo *sqliteRepo) Create(ctx context.Context, generation *entities.ImageGenerationRequest) (*entities.ImageGenerationRequest, error) {
-	generation.CreatedAt = repo.clock.Now()
+	if generation.CreatedAt.IsZero() {
+		generation.CreatedAt = repo.clock.Now()
+	}
 
 	marshalAlwaysonScripts, err := json.Marshal(generation.AlwaysonScripts)
 	if err != nil {

--- a/stable_diffusion_api/controlnet.go
+++ b/stable_diffusion_api/controlnet.go
@@ -1,0 +1,203 @@
+// This file was generated from JSON Schema using quicktype, do not modify it directly.
+// To parse and unparse this JSON data, add this code to your project and do:
+//
+//    controlnetModules, err := UnmarshalControlnetModules(bytes)
+//    bytes, err = controlnetModules.Marshal()
+
+package stable_diffusion_api
+
+import "encoding/json"
+
+func UnmarshalControlnetTypes(data []byte) (ControlnetTypes, error) {
+	var r ControlnetTypes
+	err := json.Unmarshal(data, &r)
+	return r, err
+}
+
+func (r *ControlnetTypes) Marshal() ([]byte, error) {
+	return json.Marshal(r)
+}
+
+type ControlnetTypes struct {
+	ControlTypes map[string]ControlType `json:"control_types"`
+	Modules      *ControlnetModules     `json:"-"`
+	Models       *ControlnetModels      `json:"-"`
+}
+
+type ControlType struct {
+	ModuleList    []string `json:"module_list"`
+	ModelList     []string `json:"model_list"`
+	DefaultOption string   `json:"default_option"`
+	DefaultModel  string   `json:"default_model"`
+}
+
+var ControlnetTypesCache *ControlnetTypes
+
+func AllControlnetTypes(api StableDiffusionAPI) ([]string, ControlnetTypes, ControlnetModules, ControlnetModels) {
+	types, _ := ControlnetTypesCache.GetCache(api)
+	modules, _ := ControlnetModulesCache.GetCache(api)
+	models, _ := ControlnetModelsCache.GetCache(api)
+	var typesList []string
+	for key := range types.(*ControlnetTypes).ControlTypes {
+		typesList = append(typesList, key)
+	}
+	return typesList, *types.(*ControlnetTypes), *modules.(*ControlnetModules), *models.(*ControlnetModels)
+}
+
+// Deprecated: Do not use this method. Use ControlnetModules.String or ControlnetModels.String instead.
+func (c ControlnetTypes) String(i int) string {
+	return (*c.Models)[i].Type
+}
+
+func (c ControlnetTypes) Len() int {
+	return len(c.ControlTypes)
+}
+
+func (c *ControlnetTypes) GetCache(api StableDiffusionAPI) (Cacheable, error) {
+	if c != nil {
+		return c, nil
+	}
+	if ControlnetTypesCache != nil {
+		return ControlnetTypesCache, nil
+	}
+	return c.apiGET(api)
+}
+
+func (c *ControlnetTypes) apiGET(api StableDiffusionAPI) (Cacheable, error) {
+	bytes, err := api.GET("/controlnet/control_types")
+	if err != nil {
+		return nil, err
+	}
+
+	if ControlnetTypesCache == nil {
+		ControlnetTypesCache = &ControlnetTypes{}
+	}
+	err = json.Unmarshal(bytes, ControlnetTypesCache)
+	if err != nil {
+		return nil, err
+	}
+
+	for key, controlType := range ControlnetTypesCache.ControlTypes {
+		for _, module := range controlType.ModuleList {
+			if ControlnetModulesCache == nil {
+				ControlnetModulesCache = &ControlnetModules{}
+			}
+			*ControlnetModulesCache = append(*ControlnetModulesCache, ControlnetModule{
+				Type:    key,
+				Module:  module,
+				Models:  controlType.ModelList,
+				Default: controlType.DefaultOption == module,
+			})
+		}
+		c.Modules = ControlnetModulesCache
+		for _, model := range controlType.ModelList {
+			if ControlnetModelsCache == nil {
+				ControlnetModelsCache = &ControlnetModels{}
+			}
+			*ControlnetModelsCache = append(*ControlnetModelsCache, ControlnetModel{
+				Type:    key,
+				Model:   model,
+				Modules: controlType.ModuleList,
+				Default: controlType.DefaultModel == model,
+			})
+		}
+		c.Models = ControlnetModelsCache
+	}
+
+	return ControlnetTypesCache, nil
+}
+
+func (c *ControlnetTypes) Refresh(api StableDiffusionAPI) (Cacheable, error) {
+	// no refresh available
+	return c.apiGET(api)
+}
+
+type ControlnetModule struct {
+	Type    string   `json:"type"`
+	Module  string   `json:"module"`
+	Models  []string `json:"models"`
+	Default bool     `json:"default"`
+}
+
+type ControlnetModules []ControlnetModule
+
+func (c ControlnetModules) String(i int) string {
+	return c[i].Module
+}
+
+func (c ControlnetModules) Len() int {
+	return len(c)
+}
+
+var ControlnetModulesCache *ControlnetModules
+
+func (c *ControlnetModules) GetCache(api StableDiffusionAPI) (Cacheable, error) {
+	if c != nil {
+		return c, nil
+	}
+	if ControlnetModulesCache != nil {
+		return ControlnetModulesCache, nil
+	}
+	return c.apiGET(api)
+}
+
+func (c *ControlnetModules) apiGET(api StableDiffusionAPI) (Cacheable, error) {
+	controlnetTypes, err := ControlnetTypesCache.GetCache(api)
+	if err != nil {
+		return nil, err
+	}
+	if controlnetTypes.(*ControlnetTypes).Modules != nil {
+		return controlnetTypes.(*ControlnetTypes).Modules, nil
+	}
+	return ControlnetModulesCache, nil
+}
+
+func (c *ControlnetModules) Refresh(api StableDiffusionAPI) (Cacheable, error) {
+	// no refresh available
+	return c.apiGET(api)
+}
+
+type ControlnetModel struct {
+	Type    string   `json:"type"`
+	Model   string   `json:"model"`
+	Modules []string `json:"modules"`
+	Default bool     `json:"default"`
+}
+
+type ControlnetModels []ControlnetModel
+
+func (c ControlnetModels) String(i int) string {
+	return c[i].Model
+}
+
+func (c ControlnetModels) Len() int {
+	return len(c)
+}
+
+var ControlnetModelsCache *ControlnetModels
+
+func (c *ControlnetModels) GetCache(api StableDiffusionAPI) (Cacheable, error) {
+	if c != nil {
+		return c, nil
+	}
+	if ControlnetModelsCache != nil {
+		return ControlnetModelsCache, nil
+	}
+	return c.apiGET(api)
+}
+
+func (c *ControlnetModels) apiGET(api StableDiffusionAPI) (Cacheable, error) {
+	controlnetTypes, err := ControlnetTypesCache.GetCache(api)
+	if err != nil {
+		return nil, err
+	}
+	if controlnetTypes.(*ControlnetTypes).Models != nil {
+		return controlnetTypes.(*ControlnetTypes).Models, nil
+	}
+	return ControlnetModelsCache, nil
+}
+
+func (c *ControlnetModels) Refresh(api StableDiffusionAPI) (Cacheable, error) {
+	// no refresh available
+	return c.apiGET(api)
+}

--- a/stable_diffusion_api/controlnet.go
+++ b/stable_diffusion_api/controlnet.go
@@ -20,8 +20,8 @@ func (r *ControlnetTypes) Marshal() ([]byte, error) {
 
 type ControlnetTypes struct {
 	ControlTypes map[string]ControlType `json:"control_types"`
-	Modules      *ControlnetModules     `json:"-"`
-	Models       *ControlnetModels      `json:"-"`
+	Modules      *ControlnetModules     `json:"-"` // Deprecated: Do not use this field. Use ControlnetModulesCache instead.
+	Models       *ControlnetModels      `json:"-"` // Deprecated: Do not use this field. Use ControlnetModelsCache instead.
 }
 
 type ControlType struct {
@@ -89,7 +89,7 @@ func (c *ControlnetTypes) apiGET(api StableDiffusionAPI) (Cacheable, error) {
 				Default: controlType.DefaultOption == module,
 			})
 		}
-		c.Modules = ControlnetModulesCache
+		//c.Modules = ControlnetModulesCache
 		for _, model := range controlType.ModelList {
 			if ControlnetModelsCache == nil {
 				ControlnetModelsCache = &ControlnetModels{}
@@ -101,7 +101,7 @@ func (c *ControlnetTypes) apiGET(api StableDiffusionAPI) (Cacheable, error) {
 				Default: controlType.DefaultModel == model,
 			})
 		}
-		c.Models = ControlnetModelsCache
+		//c.Models = ControlnetModelsCache
 	}
 
 	return ControlnetTypesCache, nil

--- a/stable_diffusion_api/interface.go
+++ b/stable_diffusion_api/interface.go
@@ -1,6 +1,7 @@
 package stable_diffusion_api
 
 import (
+	"github.com/sahilm/fuzzy"
 	"net/http"
 	"stable_diffusion_bot/entities"
 )
@@ -40,8 +41,7 @@ type StableDiffusionAPI interface {
 }
 
 type Cacheable interface {
-	String(int) string
-	Len() int
+	fuzzy.Source
 
 	// GetCache uses each implementation's apiGET method to fetch the cache.
 	// Make sure to check which type assertion is required, usually *Type


### PR DESCRIPTION
**Implement Controlnet and Enhance Options**

This pull request introduces significant enhancements and initial implementation for the Controlnet functionality. The following changes have been made:

1. Completed Controlnet base functionality in commit `c7c2d9da05b16d83ada9ea8c13096f65f3a62908`.

2. Prepared for future cleanup when using both `img2img` and `controlnet`, including rendering input images into a single grid and improving the output of `controlnet`.

3. Introduced a variable `c` to hold `q.currentImagine` in `text_to_image.go`, `image_to_image.go`, and `generate.go`.

4. Set the default renderer implementation to `tilerImpl`, which can handle a variable number of images to tile.

5. Removed writing to and deprecated `c.Modules` and `c.Models` in `ControlnetTypes`.

6. Adjusted `ControlnetParameters` to have `omitempty` in the JSON properties.

7. Modified the `MessageAttachment` struct's `Image` field to be a `*string`.

8. Implemented initial controlnet options, including autocomplete for the preprocessor and model list and attachment.

9. Moved `DenoisingStrength` to `Img2ImgItem` and added a new `ControlnetItem` to the queue, separating the image attachment from each other.

10. Changed the `String(int)` and `Len()` methods in the `Cacheable` interface to inherit from `fuzzy.Source`.

11. Added a `controlnetTypes()` method for dynamic updates to available types (to be deprecated as it recreates choices without consistency on restart).

12. Modified the `ControlnetParameters` struct to accept `ControlMode` and `ResizeMode` aliased types for future use.

13. Removed unused `input =` and return statements from autocomplete helper methods.

14. Calculated `extraLoras` using `min(extraLoras, 25-len(options))` and added sanity checks for the length of options, with a maximum of 25. Reduced `extraLoras` to 2, totaling 3 including the default.

15. Populated lists of available types, modules (preprocessors), and models in `controlnet.go` to easily access them via `ControlnetTypes.apiGet()`.

16. Maintained separate top-level struct lists for `Modules` and `Models` containing available Models and Modules respectively, storing the key as the type for both.

These changes lay the groundwork for more advanced controlnet features and provide better organization and flexibility for the Controlnet functionality.

**Reviewer Checklist**:

- [x] Code has been reviewed and approved by relevant team members.
- [x] Unit tests have been added or updated to ensure the correctness of the changes.
- [x] Documentation has been updated to reflect the new options and functionality.
- [x] This pull request has been tested and verified to work as intended.
- [ ] Clean up code and parsing of embeds when both Controlnet and Img2Img fields are selected