### PR TITLE
Fix: Img2Img as controlnet

### DIFF
--- a/composite_renderer/compositor.go
+++ b/composite_renderer/compositor.go
@@ -1,0 +1,117 @@
+package composite_renderer
+
+import (
+	"bytes"
+	"errors"
+	"image"
+	"image/draw"
+	"image/png"
+	"math"
+)
+
+type compositor struct{}
+
+func (c *compositor) TileImages(imageBufs []*bytes.Buffer) (*bytes.Buffer, error) {
+	numImages := len(imageBufs)
+	if numImages == 0 {
+		return nil, errors.New("no images provided")
+	}
+
+	images := make([]image.Image, numImages)
+	var totalWidth, totalHeight int
+	for i, buf := range imageBufs {
+		img, _, err := image.Decode(buf)
+		if err != nil {
+			return nil, err
+		}
+		images[i] = img
+		bounds := img.Bounds()
+		totalWidth += bounds.Dx()
+		totalHeight += bounds.Dy()
+	}
+
+	rows, cols := determineLayout(numImages, images)
+
+	canvasWidth, canvasHeight := calculateCanvasSize(images, rows, cols)
+
+	retImage := image.NewRGBA(image.Rect(0, 0, canvasWidth, canvasHeight))
+
+	var x, y, maxHeightInRow int
+	for i, img := range images {
+		if i%cols == 0 && i != 0 {
+			x = 0
+			y += maxHeightInRow
+			maxHeightInRow = 0
+		}
+
+		bounds := img.Bounds()
+		maxHeightInRow = max(maxHeightInRow, bounds.Dy())
+		draw.Draw(retImage, image.Rect(x, y, x+bounds.Dx(), y+bounds.Dy()), img, bounds.Min, draw.Over)
+		x += bounds.Dx()
+	}
+
+	imageBuf := new(bytes.Buffer)
+	err := png.Encode(imageBuf, retImage)
+	if err != nil {
+		return nil, err
+	}
+
+	return imageBuf, nil
+}
+
+func determineLayout(numImages int, images []image.Image) (rows, cols int) {
+	if numImages == 1 {
+		return 1, 1
+	}
+
+	// Basic heuristic: prefer more columns than rows to minimize empty space
+	cols = int(math.Ceil(math.Sqrt(float64(numImages))))
+	rows = int(math.Ceil(float64(numImages) / float64(cols)))
+
+	// Adjust for aspect ratios
+	portraitCount, landscapeCount, squareCount := countImageTypes(images)
+	if landscapeCount > portraitCount && landscapeCount > squareCount {
+		rows, cols = cols, rows // Prefer wider layout for mostly landscape images
+	}
+
+	return
+}
+
+func calculateCanvasSize(images []image.Image, rows, cols int) (width, height int) {
+	maxWidthPerColumn := make([]int, cols)
+	maxHeightPerRow := make([]int, rows)
+
+	for i, img := range images {
+		row := i / cols
+		col := i % cols
+		bounds := img.Bounds()
+		maxWidthPerColumn[col] = max(maxWidthPerColumn[col], bounds.Dx())
+		maxHeightPerRow[row] = max(maxHeightPerRow[row], bounds.Dy())
+	}
+
+	for _, w := range maxWidthPerColumn {
+		width += w
+	}
+	for _, h := range maxHeightPerRow {
+		height += h
+	}
+
+	return
+}
+
+func countImageTypes(images []image.Image) (portrait, landscape, square int) {
+	for _, img := range images {
+		bounds := img.Bounds()
+		width := bounds.Dx()
+		height := bounds.Dy()
+
+		if width > height {
+			landscape++
+		} else if width < height {
+			portrait++
+		} else {
+			square++
+		}
+	}
+	return
+}

--- a/composite_renderer/interface.go
+++ b/composite_renderer/interface.go
@@ -14,3 +14,7 @@ func New(yonsai bool) Renderer {
 		return &tilerImpl{}
 	}
 }
+
+func Compositor() Renderer {
+	return &compositor{}
+}

--- a/discord_bot/handlers/components.go
+++ b/discord_bot/handlers/components.go
@@ -40,6 +40,8 @@ const (
 	CancelButton Component = "cancel"
 	Interrupt    Component = "interrupt"
 
+	CancelButtonDisabled Component = "cancel_disabled"
+
 	roleSelect = "role_select"
 )
 
@@ -173,6 +175,16 @@ var Components = map[Component]discordgo.MessageComponent{
 				Label:    "Cancel",
 				Style:    discordgo.DangerButton,
 				CustomID: string(CancelButton),
+			},
+		},
+	},
+	CancelButtonDisabled: discordgo.ActionsRow{
+		Components: []discordgo.MessageComponent{
+			discordgo.Button{
+				Label:    "Cancel",
+				Style:    discordgo.DangerButton,
+				CustomID: string(CancelButton),
+				Disabled: true,
 			},
 		},
 	},

--- a/imagine_queue/queue.go
+++ b/imagine_queue/queue.go
@@ -69,13 +69,11 @@ func New(cfg Config) (Queue, error) {
 		return nil, errors.New("missing default settings repository")
 	}
 
-	compositeRenderer := composite_renderer.New(false)
-
 	return &queueImplementation{
 		stableDiffusionAPI:  cfg.StableDiffusionAPI,
 		imageGenerationRepo: cfg.ImageGenerationRepo,
 		queue:               make(chan *QueueItem, 100),
-		compositeRenderer:   compositeRenderer,
+		compositeRenderer:   composite_renderer.Compositor(),
 		defaultSettingsRepo: cfg.DefaultSettingsRepo,
 		cancelledItems:      make(map[string]bool),
 	}, nil


### PR DESCRIPTION
We've removed embedding the thumbnail while we're still generating, as it's challenging to modify the attached files afterward.

We've also removed adding the img2img to the controlnet script if controlnet is enabled, but a controlnet image is not included. Controlnet will automatically use img2img as its input

Moved appending of primary image in imageEmbedFromAttachment to the if `image != nil` block, so that we can only put in a thumbnail if desired.

Renamed thumbnails to thumbnailBuffers in generate.go and image_to_image.go

Attempt to remove empty thumbnailBuffers in generate.go and image_to_image.go

Adjusted the time.Since to only parse if it's non zero, and rounded to seconds.

Only print ADetailer scripts as Controlnet potentially have a very long base64 byte buffer

Added a new tiler called compositor that can take an arbitrary aspect ratio to attempt to tile

- [x] Removed embedding the thumbnail while still generating.
- [x] Removed adding the img2img to the controlnet script if controlnet is enabled but a controlnet image is not included.
- [x] Moved appending of the primary image in `imageEmbedFromAttachment` to the `if image != nil` block.
- [x] Renamed thumbnails to thumbnailBuffers in `generate.go` and `image_to_image.go`.
- [x] Attempted to remove empty `thumbnailBuffers` in `generate.go` and `image_to_image.go`.
- [x] Adjusted the use of `time.Since` to only parse if it's non-zero and rounded to seconds.
- [x] Only print ADetailer scripts as Controlnet potentially has a very long base64 byte buffer.
- [x] Added a new tiler called "compositor" that can take an arbitrary aspect ratio to attempt to tile.